### PR TITLE
Use Ansible limited host-list if specified

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -3,6 +3,12 @@
 - name: Gather facts again
   setup:
 
+- name: register hosts list if ansible group limit is specified
+  set_fact:
+    hosts_add_ansible_managed_hosts_groups:
+      - "{{ ansible_limit }}"
+  when: ansible_limit is defined
+
 - name: Install user-defined custom hosts file
   copy:
     src: "{{ hosts_file_src }}"


### PR DESCRIPTION
Uses the value of the limit parameter, i.e. `ansible-playbook ... -l random-group ...` to set the value of the `hosts_add_ansible_managed_hosts_groups` variable. Slightly reduces number of times you run into an issue with that variable.