### PR TITLE
Exclude Docker and k8s interfaces from hosts file

### DIFF
--- a/templates/etc_hosts.j2
+++ b/templates/etc_hosts.j2
@@ -30,7 +30,7 @@ ff02::2  ip6-allrouters
 {% for group in hosts_add_ansible_managed_hosts_groups %}
 {% for host in groups[group]|sort %}
 # {{ host }}
-{% set my_interfaces = hostvars[host]['ansible_interfaces']|select('match', '(?!^lo).*|(?!^docker).*')|default(None) -%}
+{% set my_interfaces = hostvars[host]['ansible_interfaces']|select('match', '(?!^(lo|docker|nodelocaldns)).*')|default(None) -%}
   {% if hosts_network_interface -%}
     {% set di = hosts_network_interface -%}
   {% else -%}

--- a/templates/etc_hosts.j2
+++ b/templates/etc_hosts.j2
@@ -30,7 +30,7 @@ ff02::2  ip6-allrouters
 {% for group in hosts_add_ansible_managed_hosts_groups %}
 {% for host in groups[group]|sort %}
 # {{ host }}
-{% set my_interfaces = hostvars[host]['ansible_interfaces']|select('match', '(?!^lo).*')|default(None) -%}
+{% set my_interfaces = hostvars[host]['ansible_interfaces']|select('match', '(?!^lo).*|(?!^docker).*')|default(None) -%}
   {% if hosts_network_interface -%}
     {% set di = hosts_network_interface -%}
   {% else -%}


### PR DESCRIPTION
Currently this role generates lines for each interface of each host. However, on a node with Docker and Kubernetes, this includes some "local only" interfaces that have the same IPs on all nodes! In particular, these are the `docker0` and `nodelocaldns` interfaces.

This PR changes the hosts file template to exclude those interfaces.

## Test plan

Before:

```
vagrant@virtual-mgmt01:~$ cat /etc/hosts
# Hosts file -- Don't edit manually!
#
# Ansible managed
# Localhost
127.0.0.1  localhost.localdomain  localhost

#
# Hosts managed by Ansible
#
# virtual-gpu01
172.17.0.1    virtual-gpu01-docker0
192.168.121.171    virtual-gpu01-eth0  virtual-gpu01  virtual-gpu01
10.0.0.6    virtual-gpu01-eth1
169.254.25.10    virtual-gpu01-nodelocaldns
10.233.122.0    virtual-gpu01-tunl0
# virtual-mgmt01
172.17.0.1    virtual-mgmt01-docker0
192.168.121.232    virtual-mgmt01-eth0  virtual-mgmt01  virtual-mgmt01.cluster.local
10.0.0.2    virtual-mgmt01-eth1
169.254.25.10    virtual-mgmt01-nodelocaldns
10.233.79.0    virtual-mgmt01-tunl0
```

After:

```
vagrant@virtual-mgmt01:~$ cat /etc/hosts
# Hosts file -- Don't edit manually!
#
# Ansible managed
# Localhost
127.0.0.1  localhost.localdomain  localhost

#
# Hosts managed by Ansible
#
# virtual-gpu01
192.168.121.171    virtual-gpu01-eth0  virtual-gpu01  virtual-gpu01-eth0
10.0.0.6    virtual-gpu01-eth1
10.233.122.0    virtual-gpu01-tunl0
# virtual-mgmt01
192.168.121.232    virtual-mgmt01-eth0  virtual-mgmt01  virtual-mgmt01.cluster.local
10.0.0.2    virtual-mgmt01-eth1
10.233.79.0    virtual-mgmt01-tunl0
```