### PR TITLE
Improves flexibility and reliability of hosts file generation.

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,18 +11,25 @@ An Ansible role for managing the hosts file (`/etc/hosts`). Specifically, the re
 ## Selecting the correct network interface
 
 When a host has multiple network interfaces, an entry in the hosts file will be generated for each interface with the interface name as suffix.
-If `hosts_network_interface` is selected, that IP address will also be given the names provided by `ansible_hostname` and `ansible_fqdn`.
-For example, with `hosts_network_interface` set to `eth0`, a node with three interfaces may have entries similar to the following:
+If `hosts_network_interface` is selected, that IP address will also have a fully qualified domain name included.  If `hosts_default_domain` is
+set, the FQDN will be generated using it.  Otherwise, `ansible_fqdn` will be used.  However, the value of `ansible_fqdn` can depend on the
+existing /etc/hosts file which makes this depend on /etc/hosts already being correct in order to make a correct /etc/hosts, a catch-22.
 
 ```
-10.10.0.1      node01-eth0 node01 node01.example.com
+10.10.0.1      node01.example.com node01-eth0 node01
 10.30.0.1      node01-eth1
 192.168.0.50   node01-ib0
 ```
 
-If `hosts_network_interface` is not set, `ansible_hostname` and `ansible_fqdn` will be named according to the default route.
+If `hosts_network_interface` is not set, `ansible_hostname` and `ansible_fqdn` will be named according to the interface providing the default route.
 In cases where `hosts_network_interface` is not set and there is no default route, only the interface-based names will be generated.
 
+`hosts_network_interface` can alternatively be set as an array with unique values per host.
+
+The network interfaces lo, docker, and nodelocaldns are automatically excluded.  The variable `hosts_exclude_interfaces` can
+be used to change the excluded interfaces.
+
+`hosts_interface_domain` allows including a different FQDN for specific interfaces, either cluster wide or per-host
 
 ## Requirements
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -21,9 +21,29 @@ hosts_file_snippets: []
 # IP protocol to use
 hosts_ip_protocol: 'ipv4'
 
-# Network interface to use. If empty, use the default adapter for each host.
-# NOTE: this only works if all nodes in your inventory have an adapter with the same name.
+
+# Network interface to use. Can be set either globally or per host
+# If empty, the default adapter will be used for all systems. If set per host, hosts not specified will use the default adapter
+# NOTE: the global method only works if all nodes in your inventory have an adapter with the same name.
+# hosts_network_interface: { head: eth0 }
 hosts_network_interface: ''
+
+# If hosts_default_domain is set, the default interface entry in the hosts file
+# will have the default domain used for it.  Otherwise, ansible_fqdn will be used
+# for the default entry
+hosts_default_domain: ''
+
+# This variable can be set either per interface, or per interface per host
+# hosts_interface_domain: { head: { eth1: yourdomain.com } }
+# hosts_interface_domain: { eth1: yourdomain.com }
+hosts_interface_domain: ''
+
+
+#Which interfaces should be excluded from the hosts file generation
+hosts_exclude_interfaces:
+ - lo
+ - docker
+ - nodelocaldns
 
 # Backup of previous host
 host_file_backup: no

--- a/templates/etc_hosts.j2
+++ b/templates/etc_hosts.j2
@@ -30,9 +30,11 @@ ff02::2  ip6-allrouters
 {% for group in hosts_add_ansible_managed_hosts_groups %}
 {% for host in groups[group]|sort %}
 # {{ host }}
-{% set my_interfaces = hostvars[host]['ansible_interfaces']|select('match', '(?!^(lo|docker|nodelocaldns)).*')|default(None) -%}
-  {% if hosts_network_interface -%}
-    {% set di = hosts_network_interface -%}
+{% set my_interfaces = hostvars[host]['ansible_interfaces']|select('match', '(?!^(' + hosts_exclude_interfaces|join('|') + ')).*')|default(None) -%}
+  {% if hosts_network_interface[host] is defined -%}
+      {% set di = hosts_network_interface[host] -%}
+  {% elif ((hosts_network_interface is not mapping) and hosts_network_interface) -%}
+      {% set di = hosts_network_interface -%}
   {% else -%}
     {% set di = hostvars[host]['ansible_default_' + hosts_ip_protocol]['interface']|default(None) -%}
   {% endif -%}
@@ -40,9 +42,23 @@ ff02::2  ip6-allrouters
     {% set addr = hostvars[host]['ansible_' + interface][hosts_ip_protocol]['address']|default(None) -%}
     {% if addr -%}
 {% if interface == di -%}
-{{ addr }}    {{ host }}-{{ interface }}  {{ host }}  {{ hostvars[host]['ansible_fqdn'] }}
+{% if hosts_interface_domain[host][interface] is defined -%}
+{{ addr }}    {{ host }}.{{ hosts_interface_domain[host][interface] }} {{ host }}-{{ interface }}  {{ host }}
+{% elif hosts_interface_domain[interface] is defined -%}
+{{ addr }}    {{ host }}.{{ hosts_interface_domain[interface] }} {{ host }}-{{ interface }}  {{ host }}
+{% elif hosts_default_domain -%}
+{{ addr }}    {{ host }}.{{ hosts_default_domain }} {{ host }}-{{ interface }}  {{ host }}
+{% else -%}
+{{ addr }}    {{ hostvars[host]['ansible_fqdn'] }} {{ host }}-{{ interface }}  {{ host }}
+{% endif -%}
+{% else -%}
+{% if hosts_interface_domain[host][interface] is defined -%}
+{{ addr }}    {{ host }}.{{ hosts_interface_domain[host][interface] }}    {{ host }}-{{ interface }}
+{% elif hosts_interface_domain[interface] is defined -%}
+{{ addr }}    {{ host }}.{{ hosts_interface_domain[interface] }}    {{ host }}-{{ interface }}
 {% else -%}
 {{ addr }}    {{ host }}-{{ interface }}
+{% endif -%}
 {% endif -%}
     {% endif -%}
   {% endfor -%}


### PR DESCRIPTION
- hosts_network_interfaces can now be uniquely set per host as an
  array instead of just global use as a single value

- added hosts_default_domain. If set, it's used for the default
  interface fqdn instead of using ansible_fqdn, which can come from
  the existing /etc/hosts, making the auto-generation of /etc/hosts
  dependent on what values the pre-existing file had set, affecting
  the reproducability of the results

- hosts_interface_domain enables including a different domain for entries
  for non-default interfaces.  It can be set either globally per
  interface or uniquely per host, per interface

- excluded interfaces were hard coded as lo, docker, nodelocaldns.
  moved to the variable hosts_exclude_interfaces to allow configuring
  it, such as also excluding virbr0

Signed-off-by: Rick Warner <rick@microway.com>